### PR TITLE
feat(blockquote): container model + paste whitespace normalization (#135, #136, #137)

### DIFF
--- a/docs-site/src/content/docs/guides/content.md
+++ b/docs-site/src/content/docs/guides/content.md
@@ -151,6 +151,12 @@ Inline formatting maps:
 | `<span style="font-size: ...">` | `fontSize` |
 | `<br>` | `hard_break` (InlineNode) |
 
+#### Whitespace handling
+
+HTML whitespace is normalized following the rules a browser uses to render it. Newlines, tabs, and runs of spaces in normal flow content are *insignificant*: they collapse to a single space, and whitespace at block edges is trimmed. Source-formatted or indented HTML therefore imports cleanly, and content copied from another browser (some serialize the clipboard HTML with hard-wrapped lines) is no longer split into extra paragraphs. The same normalization applies to pasted HTML.
+
+Whitespace is preserved verbatim inside `<pre>` (and any element with `white-space: pre*`), so code blocks keep their indentation. A literal line break still requires a `<br>`; a non-breaking space (`&nbsp;`) is significant and is never collapsed.
+
 ### From JSON
 
 ```ts

--- a/packages/core/src/commands/ContainerCommands.ts
+++ b/packages/core/src/commands/ContainerCommands.ts
@@ -28,13 +28,21 @@ function topLevelIndexOf(state: EditorState, blockId: BlockId): number {
 }
 
 /**
- * Wraps the top-level blocks spanned by `selection` into a single new container
- * block of `containerType`. Returns `null` when the range cannot be resolved.
+ * Wraps the top-level blocks spanned by `selection` into new container blocks of
+ * `containerType`. Returns `null` when the range cannot be resolved.
+ *
+ * `isAllowedChild` guards the container's schema (`content.allow`): blocks the
+ * container cannot legally hold (e.g. a `table` inside a `blockquote`) are left at
+ * the top level instead of being nested into an invalid document. Disallowed blocks
+ * therefore split the range into separate contiguous runs, each wrapped in its own
+ * container, mirroring `wrapIn`. Defaults to wrapping everything when omitted.
+ * Returns `null` when no block in the range is wrappable.
  */
 export function wrapSelectionInContainer(
 	state: EditorState,
 	containerType: NodeTypeName,
 	selection: Selection,
+	isAllowedChild?: (block: BlockNode) => boolean,
 ): Transaction | null {
 	const range = selectionRange(selection, state.getBlockOrder());
 	const fromIdx: number = topLevelIndexOf(state, range.from.blockId);
@@ -45,13 +53,38 @@ export function wrapSelectionInContainer(
 	const hi: number = Math.max(fromIdx, toIdx);
 
 	const blocks: readonly BlockNode[] = state.doc.children.slice(lo, hi + 1);
-	const container: BlockNode = createBlockNode(containerType, blocks, generateBlockId());
+	const allowed: (block: BlockNode) => boolean = isAllowedChild ?? (() => true);
+
+	// Group the range into maximal runs of wrappable blocks; each run becomes one
+	// container, disallowed blocks pass through unchanged and break the run.
+	const sequence: BlockNode[] = [];
+	let run: BlockNode[] = [];
+	let wrappedAny = false;
+	const flushRun = (): void => {
+		if (run.length === 0) return;
+		sequence.push(createBlockNode(containerType, run, generateBlockId()));
+		wrappedAny = true;
+		run = [];
+	};
+	for (const block of blocks) {
+		if (allowed(block)) {
+			run.push(block);
+		} else {
+			flushRun();
+			sequence.push(block);
+		}
+	}
+	flushRun();
+
+	if (!wrappedAny) return null;
 
 	const builder = state.transaction('command');
 	for (let i: number = hi; i >= lo; i--) {
 		builder.removeNode([], i);
 	}
-	builder.insertNode([], lo, container);
+	sequence.forEach((node, i) => {
+		builder.insertNode([], lo + i, node);
+	});
 	builder.setSelection(selection);
 	return builder.build();
 }

--- a/packages/core/src/input/HTMLParser.test.ts
+++ b/packages/core/src/input/HTMLParser.test.ts
@@ -136,6 +136,41 @@ describe('HTMLParser', () => {
 			expect(slice.blocks[1]?.segments).toEqual([{ text: 'more', marks: [{ type: 'bold' }] }]);
 		});
 
+		it('keeps a source-wrapped paragraph as one block (collapses newlines, issue #137)', () => {
+			// Firefox hard-wraps clipboard text/html at ~72 columns, inserting `\n`
+			// inside the text content. Those newlines are insignificant whitespace.
+			const html =
+				'<p>Do not collect the GST/HST when a customer gives you a deposit\n' +
+				'towards a taxable purchase. Collect the GST/HST on the deposit when you\n' +
+				'apply it to the purchase price.</p>';
+			const slice = parseHTML(html);
+			expect(slice.blocks).toHaveLength(1);
+			expect(slice.blocks[0]?.segments).toEqual([
+				{
+					text:
+						'Do not collect the GST/HST when a customer gives you a deposit ' +
+						'towards a taxable purchase. Collect the GST/HST on the deposit when you ' +
+						'apply it to the purchase price.',
+					marks: [],
+				},
+			]);
+		});
+
+		it('strips indentation whitespace inside list items (issue #137)', () => {
+			const slice = parseHTML(
+				'<ul>\n  <li>\n    first item\n  </li>\n  <li>\n    second\n  </li>\n</ul>',
+			);
+			expect(slice.blocks).toHaveLength(2);
+			expect(slice.blocks[0]?.segments).toEqual([{ text: 'first item', marks: [] }]);
+			expect(slice.blocks[1]?.segments).toEqual([{ text: 'second', marks: [] }]);
+		});
+
+		it('preserves whitespace inside <pre> blocks (issue #137)', () => {
+			const slice = parseHTML('<pre>  indented\n    deeper\n</pre>');
+			expect(slice.blocks).toHaveLength(1);
+			expect(slice.blocks[0]?.segments).toEqual([{ text: '  indented\n    deeper\n', marks: [] }]);
+		});
+
 		it('does not apply bold for <b style="font-weight:normal">', () => {
 			const slice = parseHTML('<p><b style="font-weight:normal">text</b></p>');
 			expect(slice.blocks[0]?.segments).toEqual([{ text: 'text', marks: [] }]);

--- a/packages/core/src/input/HTMLParser.ts
+++ b/packages/core/src/input/HTMLParser.ts
@@ -13,6 +13,7 @@ import { isMarkAllowed, isNodeTypeAllowed } from '../model/Schema.js';
 import type { SchemaRegistry } from '../model/SchemaRegistry.js';
 import type { NodeTypeName } from '../model/TypeBrands.js';
 import { markType, nodeType } from '../model/TypeBrands.js';
+import { normalizeHTMLWhitespace } from '../serialization/HTMLWhitespace.js';
 
 export interface HTMLParserOptions {
 	readonly schema: Schema;
@@ -112,6 +113,10 @@ export class HTMLParser {
 
 	/** Parses an HTML fragment and returns a ContentSlice. */
 	parse(container: DocumentFragment | HTMLElement): ContentSlice {
+		// Collapse insignificant HTML whitespace (newlines/indentation from source
+		// formatting or a browser's clipboard serializer) before walking the tree,
+		// so wrapped text stays a single block instead of splitting at every `\n`.
+		normalizeHTMLWhitespace(container);
 		const blocks: SliceBlock[] = this.parseContainer(container);
 
 		if (blocks.length === 0) {

--- a/packages/core/src/plugins/blockquote/BlockquotePlugin.test.ts
+++ b/packages/core/src/plugins/blockquote/BlockquotePlugin.test.ts
@@ -373,6 +373,44 @@ describe('BlockquotePlugin', () => {
 			]);
 		});
 
+		it('leaves a disallowed block (table) at the top level instead of nesting it', async () => {
+			// A `table` is not in the blockquote's `content.allow`, so wrapping a
+			// select-all range must not produce a schema-invalid quote-with-table.
+			const state = stateBuilder()
+				.paragraph('intro', 'p1')
+				.block('table', '', 't1')
+				.selection({ blockId: 'p1', offset: 0 }, { blockId: 't1', offset: 0 })
+				.schema(['paragraph', 'table', 'blockquote'], ['bold'])
+				.build();
+			const h = await pluginHarness(new BlockquotePlugin(), state);
+
+			h.executeCommand('toggleBlockquote');
+
+			const top = h.getState().doc.children;
+			expect(top.map((b) => b.type)).toEqual(['blockquote', 'table']);
+			const quote = top[0];
+			assertDefined(quote);
+			expect(getBlockChildren(quote).map((b) => b.type)).toEqual(['paragraph']);
+		});
+
+		it('splits the range around a disallowed block into separate quotes', async () => {
+			const state = stateBuilder()
+				.paragraph('before', 'p1')
+				.block('table', '', 't1')
+				.paragraph('after', 'p2')
+				.selection({ blockId: 'p1', offset: 0 }, { blockId: 'p2', offset: 5 })
+				.schema(['paragraph', 'table', 'blockquote'], ['bold'])
+				.build();
+			const h = await pluginHarness(new BlockquotePlugin(), state);
+
+			h.executeCommand('toggleBlockquote');
+
+			const top = h.getState().doc.children;
+			expect(top.map((b) => b.type)).toEqual(['blockquote', 'table', 'blockquote']);
+			expect(getBlockText(getBlockChildren(top[0] as BlockNode)[0] as BlockNode)).toBe('before');
+			expect(getBlockText(getBlockChildren(top[2] as BlockNode)[0] as BlockNode)).toBe('after');
+		});
+
 		it('wraps a single paragraph into a container (not a flat type swap)', async () => {
 			const state = stateBuilder()
 				.paragraph('Hello', 'p1')

--- a/packages/core/src/plugins/blockquote/BlockquotePlugin.ts
+++ b/packages/core/src/plugins/blockquote/BlockquotePlugin.ts
@@ -7,6 +7,7 @@ import {
 	liftSelectionFromContainer,
 	wrapSelectionInContainer,
 } from '../../commands/ContainerCommands.js';
+import type { BlockNode } from '../../model/Document.js';
 import { createBlockNode, generateBlockId } from '../../model/Document.js';
 import { hasAncestorOfType } from '../../model/NodeResolver.js';
 import { isCollapsed, isTextSelection } from '../../model/Selection.js';
@@ -167,7 +168,7 @@ export class BlockquotePlugin implements Plugin {
 
 		const tr = hasAncestorOfType(state.doc, sel.anchor.blockId, 'blockquote')
 			? liftSelectionFromContainer(state, nodeType('blockquote'), sel)
-			: wrapSelectionInContainer(state, nodeType('blockquote'), sel);
+			: wrapSelectionInContainer(state, nodeType('blockquote'), sel, this.isQuoteChild(context));
 
 		if (!tr) return false;
 		context.dispatch(tr);
@@ -180,9 +181,33 @@ export class BlockquotePlugin implements Plugin {
 		const sel = state.selection;
 		if (!isTextSelection(sel)) return false;
 
-		const tr = wrapSelectionInContainer(state, nodeType('blockquote'), sel);
+		const tr = wrapSelectionInContainer(
+			state,
+			nodeType('blockquote'),
+			sel,
+			this.isQuoteChild(context),
+		);
 		if (!tr) return false;
 		context.dispatch(tr);
 		return true;
+	}
+
+	/**
+	 * Builds a predicate that reports whether a block may legally become a direct
+	 * child of the blockquote container, derived from the registered NodeSpec's
+	 * `content.allow` (single source of truth). Matches both concrete child types
+	 * and group names (e.g. `block`), so blocks the quote cannot hold (e.g. a
+	 * `table`) are excluded rather than nested into an invalid document.
+	 */
+	private isQuoteChild(context: PluginContext): (block: BlockNode) => boolean {
+		const registry = context.getSchemaRegistry();
+		const allow: ReadonlySet<string> = new Set(
+			registry.getNodeSpec(nodeType('blockquote'))?.content?.allow ?? [],
+		);
+		return (block: BlockNode): boolean => {
+			if (allow.has(block.type)) return true;
+			const group: string | undefined = registry.getNodeSpec(block.type)?.group;
+			return group !== undefined && allow.has(group);
+		};
 	}
 }

--- a/packages/core/src/serialization/DocumentParser.test.ts
+++ b/packages/core/src/serialization/DocumentParser.test.ts
@@ -9,6 +9,7 @@ import {
 	getInlineChildren,
 	isInlineNode,
 } from '../model/Document.js';
+import { formatHTML } from '../model/HTMLUtils.js';
 import type { InlineNodeSpec } from '../model/InlineNodeSpec.js';
 import type { MarkSpec } from '../model/MarkSpec.js';
 import type { SchemaRegistry } from '../model/SchemaRegistry.js';
@@ -241,6 +242,81 @@ describe('parseHTMLToDocument', () => {
 		if (!block) return;
 		expect(block.type).toBe('paragraph');
 		expect(getBlockText(block)).toBe('content');
+	});
+
+	// --- Whitespace normalization (issue #137) ---
+
+	describe('whitespace normalization (#137)', () => {
+		it('collapses source-wrapped newlines so a paragraph stays one block', () => {
+			const html =
+				'<p>Do not collect the GST/HST when a customer gives you a deposit\n' +
+				'towards a taxable purchase. Collect the GST/HST on the deposit when you\n' +
+				'apply it to the purchase price.</p>';
+			const doc = parseHTMLToDocument(html, createTestRegistry());
+			expect(doc.children).toHaveLength(1);
+			const block = doc.children[0];
+			if (!block) return;
+			expect(getBlockText(block)).toBe(
+				'Do not collect the GST/HST when a customer gives you a deposit ' +
+					'towards a taxable purchase. Collect the GST/HST on the deposit when you ' +
+					'apply it to the purchase price.',
+			);
+		});
+
+		it('strips indentation whitespace inside list items', () => {
+			const doc = parseHTMLToDocument(
+				'<ul>\n  <li>\n    first item\n  </li>\n  <li>\n    second\n  </li>\n</ul>',
+				createTestRegistry(),
+			);
+			expect(doc.children).toHaveLength(2);
+			const first = doc.children[0];
+			const second = doc.children[1];
+			if (!first || !second) return;
+			expect(getBlockText(first)).toBe('first item');
+			expect(getBlockText(second)).toBe('second');
+		});
+
+		it('preserves whitespace inside <pre> code blocks', () => {
+			const registry = {
+				getNodeSpec: () => undefined,
+				getInlineNodeSpec: () => undefined,
+				getMarkSpec: () => undefined,
+				getMarkTypes: () => [],
+				getBlockParseRules: () => [{ rule: { tag: 'pre' }, type: 'code_block' }],
+				getMarkParseRules: () => [],
+				getInlineParseRules: () => [],
+				getAllowedTags: () => ['p', 'pre', 'code'],
+				getAllowedAttrs: () => ['class'],
+			} as unknown as SchemaRegistry;
+
+			const doc = parseHTMLToDocument('<pre>  indented\n    deeper\n</pre>', registry);
+			expect(doc.children).toHaveLength(1);
+			const block = doc.children[0];
+			if (!block) return;
+			expect(block.type).toBe('code_block');
+			expect(getBlockText(block)).toBe('  indented\n    deeper\n');
+		});
+
+		it('is idempotent through a pretty-printed serialization round-trip', () => {
+			const registry = createTestRegistry();
+			const doc = createDocument([
+				createBlockNode(nodeType('paragraph'), [createTextNode('First paragraph of text.')]),
+				createBlockNode(nodeType('paragraph'), [createTextNode('Second paragraph of text.')]),
+			]);
+
+			// `getContentHTML({ pretty: true })` runs the serialized HTML through
+			// formatHTML, which indents blocks onto their own lines. Re-parsing must
+			// not let that insignificant whitespace leak into the block text.
+			const pretty: string = formatHTML(serializeDocumentToHTML(doc));
+			const reparsed = parseHTMLToDocument(pretty, registry);
+
+			expect(reparsed.children).toHaveLength(2);
+			const first = reparsed.children[0];
+			const second = reparsed.children[1];
+			if (!first || !second) return;
+			expect(getBlockText(first)).toBe('First paragraph of text.');
+			expect(getBlockText(second)).toBe('Second paragraph of text.');
+		});
 	});
 
 	// --- Alignment parsing ---

--- a/packages/core/src/serialization/DocumentParser.ts
+++ b/packages/core/src/serialization/DocumentParser.ts
@@ -18,6 +18,7 @@ import type { SchemaRegistry } from '../model/SchemaRegistry.js';
 import { type InlineTypeName, inlineType, markType, nodeType } from '../model/TypeBrands.js';
 import { adoptBlockId } from './BlockIdHTML.js';
 import { VALID_ALIGNMENTS, VALID_DIRECTIONS } from './DocumentSerializer.js';
+import { normalizeHTMLWhitespace } from './HTMLWhitespace.js';
 
 /** Options for `parseHTMLToDocument` when importing class-based HTML. */
 export interface ParseHTMLOptions {
@@ -61,6 +62,10 @@ export function parseHTMLToDocument(
 	if (options?.styleMap) {
 		rehydrateClasses(root, options.styleMap);
 	}
+
+	// Collapse insignificant HTML whitespace so source-formatted/indented input does
+	// not leave stray newlines and indentation inside block text content.
+	normalizeHTMLWhitespace(root);
 
 	const blockRules = registry?.getBlockParseRules() ?? [];
 	const blocks: BlockNode[] = [];

--- a/packages/core/src/serialization/HTMLWhitespace.test.ts
+++ b/packages/core/src/serialization/HTMLWhitespace.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeHTMLWhitespace } from './HTMLWhitespace.js';
+
+/** Parses HTML into a fragment, runs the normalizer, and returns the fragment. */
+function normalize(html: string): DocumentFragment {
+	const template: HTMLTemplateElement = document.createElement('template');
+	template.innerHTML = html;
+	normalizeHTMLWhitespace(template.content);
+	return template.content;
+}
+
+/** Normalizes HTML and returns the resulting `textContent`. */
+function normalizedText(html: string): string {
+	return normalize(html).textContent ?? '';
+}
+
+const NBSP: string = String.fromCharCode(0x00a0);
+
+describe('normalizeHTMLWhitespace', () => {
+	describe('collapsing within a block', () => {
+		it('collapses embedded newlines to a single space (Firefox clipboard wrapping)', () => {
+			const html =
+				'<p>Do not collect the GST/HST when a customer gives you a deposit\n' +
+				'towards a taxable purchase. Collect the GST/HST on the deposit when you\n' +
+				'apply it to the purchase price.</p>';
+			expect(normalizedText(html)).toBe(
+				'Do not collect the GST/HST when a customer gives you a deposit ' +
+					'towards a taxable purchase. Collect the GST/HST on the deposit when you ' +
+					'apply it to the purchase price.',
+			);
+		});
+
+		it('collapses runs of spaces, tabs and newlines to one space', () => {
+			expect(normalizedText('<p>a \t\n  b</p>')).toBe('a b');
+		});
+
+		it('trims leading and trailing whitespace at block edges', () => {
+			expect(normalizedText('<p>\n  hello world  \n</p>')).toBe('hello world');
+		});
+	});
+
+	describe('preserving significant whitespace', () => {
+		it('preserves non-breaking spaces (does not treat U+00A0 as collapsible)', () => {
+			expect(normalizedText('<p>a&nbsp;&nbsp;b</p>')).toBe(`a${NBSP}${NBSP}b`);
+		});
+
+		it('preserves whitespace inside <pre>', () => {
+			expect(normalizedText('<pre>  line1\n    line2\n</pre>')).toBe('  line1\n    line2\n');
+		});
+
+		it('preserves whitespace under white-space: pre-wrap', () => {
+			expect(normalizedText('<div style="white-space: pre-wrap">a\n  b</div>')).toBe('a\n  b');
+		});
+	});
+
+	describe('cross-element collapsing', () => {
+		it('keeps a single space between inline siblings', () => {
+			expect(normalizedText('<p><strong>bold</strong> and <em>italic</em></p>')).toBe(
+				'bold and italic',
+			);
+		});
+
+		it('collapses a newline that falls at an inline element boundary', () => {
+			expect(normalizedText('<p>foo\n<strong>bar</strong></p>')).toBe('foo bar');
+		});
+
+		it('does not introduce a double space across inline boundaries', () => {
+			// Trailing space in one node + leading space in the next collapse to one.
+			expect(normalizedText('<p><span>foo </span><span> bar</span></p>')).toBe('foo bar');
+		});
+
+		it('trims trailing whitespace that ends inside a nested inline element', () => {
+			expect(normalizedText('<p>foo <strong>bar </strong></p>')).toBe('foo bar');
+		});
+	});
+
+	describe('block boundaries', () => {
+		it('resets collapsing per block, no leading/trailing space leaks between blocks', () => {
+			const fragment: DocumentFragment = normalize('<p>  first  </p>\n  <p>  second  </p>');
+			const paragraphs: HTMLParagraphElement[] = Array.from(fragment.querySelectorAll('p'));
+			expect(paragraphs.map((p) => p.textContent)).toEqual(['first', 'second']);
+		});
+
+		it('drops whitespace-only text between list items', () => {
+			const fragment: DocumentFragment = normalize(
+				'<ul>\n  <li>  a  </li>\n  <li>  b  </li>\n</ul>',
+			);
+			const items: HTMLLIElement[] = Array.from(fragment.querySelectorAll('li'));
+			expect(items.map((li) => li.textContent)).toEqual(['a', 'b']);
+		});
+	});
+
+	describe('hard breaks (deliberately left intact)', () => {
+		it('does not remove <br> elements', () => {
+			const fragment: DocumentFragment = normalize('<p>line1<br>line2</p>');
+			expect(fragment.querySelectorAll('br')).toHaveLength(1);
+		});
+	});
+});

--- a/packages/core/src/serialization/HTMLWhitespace.ts
+++ b/packages/core/src/serialization/HTMLWhitespace.ts
@@ -1,0 +1,172 @@
+/**
+ * HTML whitespace normalization, shared by the paste parser (`HTMLParser`) and the
+ * `setContentHTML` parser (`DocumentParser`).
+ *
+ * Per the CSS Text / HTML whitespace processing model for `white-space: normal`,
+ * whitespace in normal flow content is *insignificant*: runs of ASCII whitespace
+ * (space, tab, line feed, carriage return, form feed) collapse to a single space,
+ * and whitespace at the edges of a block collapses away entirely. Only `<br>` is a
+ * real line break. Source-formatted HTML (server-rendered, hand-indented, or
+ * hard-wrapped by a browser's clipboard serializer) therefore carries newlines and
+ * indentation that must NOT survive parsing.
+ *
+ * This pass rewrites text-node data in place so both parsers can walk a tree whose
+ * whitespace already matches what a browser would render. It only touches
+ * `Text.data`; marks, block ids, and attributes are left untouched.
+ */
+
+/**
+ * ASCII whitespace per the HTML spec. Deliberately NOT `\s`: `\s` also matches
+ * non-breaking space (` `) and other Unicode spaces, which are significant
+ * content and must be preserved verbatim.
+ */
+const COLLAPSIBLE_WHITESPACE: RegExp = /[ \t\n\r\f]+/g;
+
+/**
+ * Tags that establish a block formatting context in normal flow. Each starts a
+ * fresh inline run whose leading/trailing whitespace is trimmed independently.
+ * Self-contained (not coupled to the parsers' tag sets); unknown tags are treated
+ * as inline.
+ */
+const FLOW_BLOCK_TAGS: ReadonlySet<string> = new Set([
+	'P',
+	'DIV',
+	'H1',
+	'H2',
+	'H3',
+	'H4',
+	'H5',
+	'H6',
+	'BLOCKQUOTE',
+	'UL',
+	'OL',
+	'LI',
+	'TABLE',
+	'THEAD',
+	'TBODY',
+	'TFOOT',
+	'TR',
+	'TD',
+	'TH',
+	'HR',
+	'FIGURE',
+	'FIGCAPTION',
+	'SECTION',
+	'ARTICLE',
+	'HEADER',
+	'FOOTER',
+	'MAIN',
+	'ASIDE',
+	'NAV',
+	'DL',
+	'DT',
+	'DD',
+]);
+
+/** Tags whose descendant whitespace is significant and must be preserved verbatim. */
+const PRESERVE_TAGS: ReadonlySet<string> = new Set(['PRE', 'TEXTAREA']);
+
+/** `white-space` values that preserve whitespace (the `pre*` family). */
+const PRESERVE_WHITESPACE_VALUES: ReadonlySet<string> = new Set([
+	'pre',
+	'pre-wrap',
+	'pre-line',
+	'break-spaces',
+]);
+
+/** Mutable state threaded through a single inline formatting context. */
+interface CollapseState {
+	/** Most recent non-empty text node in this context, for trailing-space trimming. */
+	lastTextNode: Text | null;
+	/**
+	 * Whether a leading space on the next text node should be dropped. True at the
+	 * start of a context and after any text node that ended with a space.
+	 */
+	collapsePending: boolean;
+}
+
+/**
+ * Collapses insignificant HTML whitespace throughout `root`, mutating text-node
+ * data in place. Call once on a (disposable) parsed fragment before walking it.
+ */
+export function normalizeHTMLWhitespace(root: DocumentFragment | HTMLElement): void {
+	normalizeContext(root);
+}
+
+/** Processes one inline formatting context, then trims its trailing whitespace. */
+function normalizeContext(container: DocumentFragment | HTMLElement): void {
+	const state: CollapseState = { lastTextNode: null, collapsePending: true };
+	for (const child of Array.from(container.childNodes)) {
+		processNode(child, state);
+	}
+	trimTrailingSpace(state.lastTextNode);
+}
+
+function processNode(node: ChildNode, state: CollapseState): void {
+	if (node.nodeType === Node.TEXT_NODE) {
+		collapseTextNode(node as Text, state);
+		return;
+	}
+	if (node.nodeType !== Node.ELEMENT_NODE) return;
+
+	const el = node as HTMLElement;
+
+	// Whitespace-preserving subtree (code blocks etc.): end the current inline run
+	// and leave the subtree untouched.
+	if (isPreserveElement(el)) {
+		endInlineRun(state);
+		return;
+	}
+
+	// Block element: the current inline run ends here; recurse as a fresh context.
+	if (isFlowBlockElement(el)) {
+		endInlineRun(state);
+		normalizeContext(el);
+		return;
+	}
+
+	// Inline element: keep collapsing within the same context.
+	for (const child of Array.from(el.childNodes)) {
+		processNode(child, state);
+	}
+}
+
+/** Collapses whitespace runs in a text node and drops a leading space when pending. */
+function collapseTextNode(text: Text, state: CollapseState): void {
+	let data: string = text.data.replace(COLLAPSIBLE_WHITESPACE, ' ');
+	if (state.collapsePending && data.startsWith(' ')) {
+		data = data.slice(1);
+	}
+	text.data = data;
+
+	// Fully collapsed away (e.g. a whitespace-only node): leave `collapsePending` as
+	// is so a later node still drops its leading space.
+	if (data.length === 0) return;
+
+	state.collapsePending = data.endsWith(' ');
+	state.lastTextNode = text;
+}
+
+/** Ends the current inline run at a block/preserve boundary and resets state. */
+function endInlineRun(state: CollapseState): void {
+	trimTrailingSpace(state.lastTextNode);
+	state.lastTextNode = null;
+	state.collapsePending = true;
+}
+
+/** Removes the single (already-collapsed) trailing space from a text node, if any. */
+function trimTrailingSpace(node: Text | null): void {
+	if (node?.data.endsWith(' ')) {
+		node.data = node.data.slice(0, -1);
+	}
+}
+
+function isFlowBlockElement(el: HTMLElement): boolean {
+	return FLOW_BLOCK_TAGS.has(el.tagName);
+}
+
+function isPreserveElement(el: HTMLElement): boolean {
+	if (PRESERVE_TAGS.has(el.tagName)) return true;
+	const whiteSpace: string = (el.style?.whiteSpace ?? '').toLowerCase();
+	return PRESERVE_WHITESPACE_VALUES.has(whiteSpace);
+}


### PR DESCRIPTION
Resolves the three problems reported in #135 by splitting them into their root causes (#136, #137) and fixing each cleanly.

## #136 — Blockquote is now a container block (B2)

Previously the blockquote command only acted on the selection anchor, so a multi-block selection converted only the first block and quoting a list destroyed it. Blockquote is now a **container block** that wraps other blocks, mirroring HTML flow-content semantics.

- `NodeSpec.content` allows block children (paragraph, heading, list_item, blockquote, horizontal_rule, code_block); not `isolating`, so the caret flows across the container edges.
- `commands/ContainerCommands.ts`: generic `wrapSelectionInContainer` / `liftSelectionFromContainer`, preserving block identity. `toggleBlockquote` wraps or lifts; `setBlockquote` wraps. `isActive` is ancestor-based.
- Input rule `> ` wraps the paragraph into a quote.
- Container keyboard navigation: Enter exits an empty last child, Backspace lifts the first child, both dissolving an emptied quote.
- `DocumentParser` parses `<blockquote>` recursively; paste routes blockquotes through the container-aware parser. `getEditorText` descends into containers.

## #137 — HTML whitespace normalization on paste/import

Newlines in pasted HTML text were treated as significant, so Firefox's hard-wrapped clipboard HTML split one paragraph into several.

- New shared `serialization/HTMLWhitespace.ts` implements the CSS `white-space: normal` model: collapse runs of ASCII whitespace to a single space, trim at block edges, exempt `pre`/`textarea`/`white-space: pre*`. Non-breaking spaces preserved.
- Wired into both parse paths (`HTMLParser.parse` for paste, `parseHTMLToDocument` for `setContentHTML`).

## Review follow-up fix — wrap respects `content.allow`

`wrapSelectionInContainer` wrapped every block in range, but `applyInsertNode` does no schema validation, so a `table` (not in the blockquote allow-list) could be nested into a schema-invalid document on "select all then Blockquote".

- Added an `isAllowedChild` predicate: disallowed blocks break the range into maximal runs, each wrapped in its own container (wrapIn-style); disallowed blocks stay at the top level.
- The predicate is derived from the registered NodeSpec `content.allow` (single source of truth).
- Regression tests: a table stays at the top level; an interspersed table splits the selection into two quotes.

## Verification

- Unit: 3808 passing
- Typecheck + lint (biome): clean
- E2E: 78 passing, 1 documented `test.fixme` (lone-quote cut→paste residual, valid-not-corrupt)

## Known low-severity follow-ups (not in this PR)

- `content.min: 1` is declarative, not enforced.
- Toggling off a nested (non-top-level) quote is a no-op.
- `<br>` still splits paragraphs on the paste path while a `HardBreakPlugin` exists.