### PR TITLE
fix: coalesce blockquote inline runs (#141) and stop font-size combobox key double-handling (#144)

### DIFF
--- a/e2e/font-size.spec.ts
+++ b/e2e/font-size.spec.ts
@@ -35,6 +35,33 @@ test.describe('FontSizePlugin', () => {
 		await expect(popup).toBeVisible();
 	});
 
+	test('ArrowDown advances the preset focus by exactly one, never two (#144)', async ({
+		editor,
+		page,
+	}) => {
+		const sizeBtn = editor.markButton('fontSize');
+		await sizeBtn.click();
+
+		const popup = editor.root.locator('.notectl-font-size-picker');
+		await expect(popup).toBeVisible();
+
+		const input = popup.locator('input');
+		await input.click();
+
+		const items = popup.locator(SIZE_ITEM);
+
+		// Assert on real DOM focus, not the bespoke `--focused` class: the double-advance
+		// bug moves actual focus via the toolbar's generic handler while the class stays
+		// single-stepped, so only `toBeFocused()` can detect a skipped preset.
+		// From the input, ArrowDown must land on the FIRST preset (index 0), not the second.
+		await page.keyboard.press('ArrowDown');
+		await expect(items.nth(0)).toBeFocused();
+
+		// A second ArrowDown advances to the SECOND preset (index 1), not the third.
+		await page.keyboard.press('ArrowDown');
+		await expect(items.nth(1)).toBeFocused();
+	});
+
 	test('Selecting default size (12) removes font-size mark', async ({ editor, page }) => {
 		await editor.recreateWithPlugins({
 			toolbar: [

--- a/packages/core/src/plugins/font-size/FontSizePopup.test.ts
+++ b/packages/core/src/plugins/font-size/FontSizePopup.test.ts
@@ -209,6 +209,43 @@ describe('renderFontSizePopup', () => {
 			const firstItem = container.querySelector('.notectl-font-size-picker__item');
 			expect(firstItem?.classList.contains('notectl-font-size-picker__item--focused')).toBe(true);
 		});
+
+		// Regression: #144 — the combobox must stop navigation
+		// keys from bubbling so the toolbar's generic popup handler does not advance
+		// focus a second time. The container is where ToolbarPopupController binds
+		// its handler in production.
+		it('stops ArrowDown on the list from bubbling to the toolbar handler (#144)', () => {
+			const { container } = renderPopup({ sizes: [12, 16, 24] });
+			const toolbarHandler = vi.fn();
+			container.addEventListener('keydown', toolbarHandler);
+
+			const list = getList(container);
+			list.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
+
+			expect(toolbarHandler).not.toHaveBeenCalled();
+		});
+
+		it('stops ArrowDown on the input from bubbling to the toolbar handler (#144)', () => {
+			const { container } = renderPopup({ sizes: [12, 16, 24] });
+			const toolbarHandler = vi.fn();
+			container.addEventListener('keydown', toolbarHandler);
+
+			const input = getInput(container);
+			input.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
+
+			expect(toolbarHandler).not.toHaveBeenCalled();
+		});
+
+		it('ArrowDown on input lands on the first item, never the second (#144)', () => {
+			const { container } = renderPopup({ sizes: [12, 16, 24] });
+
+			const input = getInput(container);
+			input.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
+
+			const items = container.querySelectorAll('.notectl-font-size-picker__item');
+			expect(items[0]?.classList.contains('notectl-font-size-picker__item--focused')).toBe(true);
+			expect(items[1]?.classList.contains('notectl-font-size-picker__item--focused')).toBe(false);
+		});
 	});
 
 	describe('mouse interaction', () => {

--- a/packages/core/src/plugins/font-size/FontSizePopup.ts
+++ b/packages/core/src/plugins/font-size/FontSizePopup.ts
@@ -172,33 +172,41 @@ function attachKeyboardNavigation(
 		}
 	};
 
+	// As an editable combobox (input + listbox), this popup owns its keyboard
+	// model. `consume` claims a handled key so the toolbar's generic popup
+	// handler does not also act on it and advance focus a second time (#144).
+	const consume = (e: KeyboardEvent): void => {
+		e.preventDefault();
+		e.stopPropagation();
+	};
+
 	input.addEventListener('keydown', (e: KeyboardEvent) => {
 		if (e.key === 'Enter') {
-			e.preventDefault();
+			consume(e);
 			const val: number = Number.parseInt(input.value, 10);
 			if (!Number.isNaN(val) && val >= MIN_CUSTOM_SIZE && val <= MAX_CUSTOM_SIZE) {
 				selectSize(context, val, config.defaultSize);
 				config.onClose({ restoreFocusTo: config.contentElement });
 			}
 		} else if (e.key === 'ArrowDown') {
-			e.preventDefault();
+			consume(e);
 			setFocused(0);
 			items[0]?.focus();
 		} else if (e.key === 'Escape') {
-			e.preventDefault();
+			consume(e);
 			config.onClose({ restoreFocusTo: config.contentElement });
 		}
 	});
 
 	list.addEventListener('keydown', (e: KeyboardEvent) => {
 		if (e.key === 'ArrowDown') {
-			e.preventDefault();
+			consume(e);
 			if (focusedIndex < items.length - 1) {
 				setFocused(focusedIndex + 1);
 				items[focusedIndex]?.focus();
 			}
 		} else if (e.key === 'ArrowUp') {
-			e.preventDefault();
+			consume(e);
 			if (focusedIndex > 0) {
 				setFocused(focusedIndex - 1);
 				items[focusedIndex]?.focus();
@@ -207,14 +215,14 @@ function attachKeyboardNavigation(
 				input.focus();
 			}
 		} else if (e.key === 'Enter') {
-			e.preventDefault();
+			consume(e);
 			const selectedSize: number | undefined = config.sizes[focusedIndex];
 			if (focusedIndex >= 0 && focusedIndex < config.sizes.length && selectedSize !== undefined) {
 				selectSize(context, selectedSize, config.defaultSize);
 				config.onClose({ restoreFocusTo: config.contentElement });
 			}
 		} else if (e.key === 'Escape') {
-			e.preventDefault();
+			consume(e);
 			config.onClose({ restoreFocusTo: config.contentElement });
 		}
 	});

--- a/packages/core/src/serialization/DocumentParser.test.ts
+++ b/packages/core/src/serialization/DocumentParser.test.ts
@@ -1646,3 +1646,181 @@ function createListParseRegistry(): SchemaRegistry {
 		getAllowedAttrs: () => ['style', 'dir'],
 	} as unknown as SchemaRegistry;
 }
+
+// Regression: #141 — blockquote (and table cells) must coalesce consecutive
+// inline content into a single paragraph with marks intact, not fragment it.
+describe('blockquote mixed inline content (#141)', () => {
+	function createInlineAwareRegistry(): SchemaRegistry {
+		const blockRules = [
+			{ rule: { tag: 'p' }, type: 'paragraph' },
+			{ rule: { tag: 'blockquote' }, type: 'blockquote' },
+			{ rule: { tag: 'li' }, type: 'list_item' },
+		];
+		return {
+			getNodeSpec: () => undefined,
+			getInlineNodeSpec: () => undefined,
+			getMarkSpec: () => undefined,
+			getMarkTypes: () => ['italic', 'bold'],
+			getBlockParseRules: () => blockRules,
+			getMarkParseRules: () => [
+				{ rule: { tag: 'em' }, type: 'italic' },
+				{ rule: { tag: 'i' }, type: 'italic' },
+				{ rule: { tag: 'strong' }, type: 'bold' },
+				{
+					rule: {
+						tag: 'a',
+						getAttrs: (el: HTMLElement) => ({ href: el.getAttribute('href') ?? '' }),
+					},
+					type: 'link',
+				},
+			],
+			getInlineParseRules: () => [],
+			getAllowedTags: () => [
+				'p',
+				'br',
+				'blockquote',
+				'em',
+				'i',
+				'strong',
+				'a',
+				'ul',
+				'ol',
+				'li',
+				'table',
+				'tbody',
+				'tr',
+				'td',
+				'th',
+			],
+			getAllowedAttrs: () => ['style', 'dir', 'href'],
+		} as unknown as SchemaRegistry;
+	}
+
+	it('coalesces mixed inline content into one paragraph with marks preserved', () => {
+		const registry = createInlineAwareRegistry();
+		const doc = parseHTMLToDocument(
+			'<blockquote>This is a <em>great</em> quote.</blockquote>',
+			registry,
+		);
+
+		const quote = doc.children[0];
+		expect(quote?.type).toBe('blockquote');
+
+		const quoteChildren = getBlockChildren(quote as never);
+		expect(quoteChildren).toHaveLength(1);
+		expect(quoteChildren[0]?.type).toBe('paragraph');
+		expect(getBlockText(quoteChildren[0] as never)).toBe('This is a great quote.');
+
+		const inline = getInlineChildren(quoteChildren[0] as never);
+		const italicRun = inline.find((n) => !isInlineNode(n) && n.text === 'great') as
+			| { readonly marks?: readonly Mark[] }
+			| undefined;
+		expect(italicRun?.marks?.some((m) => m.type === 'italic')).toBe(true);
+
+		// The surrounding text must NOT carry the italic mark.
+		const plainRun = inline.find((n) => !isInlineNode(n) && n.text === 'This is a ') as
+			| { readonly marks?: readonly Mark[] }
+			| undefined;
+		expect(plainRun?.marks?.some((m) => m.type === 'italic') ?? false).toBe(false);
+	});
+
+	it('preserves a link mark with its href on the coalesced run (issue headline)', () => {
+		const registry = createInlineAwareRegistry();
+		const doc = parseHTMLToDocument(
+			'<blockquote>See <a href="https://example.com/">the docs</a> for more.</blockquote>',
+			registry,
+		);
+
+		const quoteChildren = getBlockChildren(doc.children[0] as never);
+		expect(quoteChildren).toHaveLength(1);
+		expect(getBlockText(quoteChildren[0] as never)).toBe('See the docs for more.');
+
+		const inline = getInlineChildren(quoteChildren[0] as never);
+		const linkRun = inline.find((n) => !isInlineNode(n) && n.text === 'the docs') as
+			| { readonly marks?: readonly Mark[] }
+			| undefined;
+		const linkMark = linkRun?.marks?.find((m) => m.type === 'link') as
+			| { readonly attrs?: { readonly href?: string } }
+			| undefined;
+		expect(linkMark).toBeDefined();
+		expect(linkMark?.attrs?.href).toBe('https://example.com/');
+	});
+
+	it('coalesces direct mixed inline content in a table cell into one paragraph', () => {
+		const registry = createInlineAwareRegistry();
+		const doc = parseHTMLToDocument(
+			'<table><tr><td>text <em>x</em> end</td></tr></table>',
+			registry,
+		);
+
+		const table = doc.children[0];
+		const row = getBlockChildren(table as never)[0];
+		const cell = getBlockChildren(row as never)[0];
+		const cellChildren = getBlockChildren(cell as never);
+		expect(cellChildren).toHaveLength(1);
+		expect(cellChildren[0]?.type).toBe('paragraph');
+		expect(getBlockText(cellChildren[0] as never)).toBe('text x end');
+	});
+
+	it('coalesces mixed inline content inside a table cell blockquote', () => {
+		const registry = createInlineAwareRegistry();
+		const doc = parseHTMLToDocument(
+			'<table><tr><td><blockquote>text <em>x</em> end</blockquote></td></tr></table>',
+			registry,
+		);
+
+		const table = doc.children[0];
+		const row = getBlockChildren(table as never)[0];
+		const cell = getBlockChildren(row as never)[0];
+		const quote = getBlockChildren(cell as never)[0];
+		expect(quote?.type).toBe('blockquote');
+
+		const quoteChildren = getBlockChildren(quote as never);
+		expect(quoteChildren).toHaveLength(1);
+		expect(quoteChildren[0]?.type).toBe('paragraph');
+		expect(getBlockText(quoteChildren[0] as never)).toBe('text x end');
+	});
+
+	it('still nests genuine block children (paragraphs, lists) recursively', () => {
+		const registry = createInlineAwareRegistry();
+		const doc = parseHTMLToDocument(
+			'<blockquote><p>First</p><ul><li>One</li><li>Two</li></ul></blockquote>',
+			registry,
+		);
+
+		const quote = doc.children[0];
+		const children = getBlockChildren(quote as never);
+		expect(children).toHaveLength(3);
+		expect(children[0]?.type).toBe('paragraph');
+		expect(getBlockText(children[0] as never)).toBe('First');
+		expect(children[1]?.type).toBe('list_item');
+		expect(children[2]?.type).toBe('list_item');
+	});
+
+	it('mixes a leading inline run with a following block child', () => {
+		const registry = createInlineAwareRegistry();
+		const doc = parseHTMLToDocument(
+			'<blockquote>Intro <strong>bold</strong> text<p>Then a paragraph</p></blockquote>',
+			registry,
+		);
+
+		const quote = doc.children[0];
+		const children = getBlockChildren(quote as never);
+		expect(children).toHaveLength(2);
+		expect(children[0]?.type).toBe('paragraph');
+		expect(getBlockText(children[0] as never)).toBe('Intro bold text');
+		expect(children[1]?.type).toBe('paragraph');
+		expect(getBlockText(children[1] as never)).toBe('Then a paragraph');
+	});
+
+	it('keeps a single empty paragraph for an empty blockquote', () => {
+		const registry = createInlineAwareRegistry();
+		const doc = parseHTMLToDocument('<blockquote></blockquote>', registry);
+
+		const quote = doc.children[0];
+		const children = getBlockChildren(quote as never);
+		expect(children).toHaveLength(1);
+		expect(children[0]?.type).toBe('paragraph');
+		expect(getBlockText(children[0] as never)).toBe('');
+	});
+});

--- a/packages/core/src/serialization/DocumentParser.ts
+++ b/packages/core/src/serialization/DocumentParser.ts
@@ -363,16 +363,17 @@ function parseBlockquoteElement(
 	registry?: SchemaRegistry,
 ): void {
 	const blockRules = registry?.getBlockParseRules() ?? [];
-	const innerBlocks: BlockNode[] = [];
+	const innerBlocks: BlockNode[] = parseBlockContainerChildren(
+		el,
+		blockRules,
+		adoptedIds,
+		registry,
+	);
 
-	for (const child of Array.from(el.childNodes)) {
-		parseChildNode(child, innerBlocks, blockRules, adoptedIds, registry);
-	}
-
-	// Pure inline content (e.g. `<blockquote>text</blockquote>`): wrap in a paragraph.
+	// Empty or whitespace-only blockquote: keep a single empty paragraph so the
+	// container always holds editable content.
 	if (innerBlocks.length === 0) {
-		const inlineContent = parseElementToInlineContent(el, registry);
-		innerBlocks.push(createBlockNode(nodeType('paragraph'), inlineContent));
+		innerBlocks.push(createBlockNode(nodeType('paragraph'), [createTextNode('')]));
 	}
 
 	// Preserve direction/alignment on the container so the HTML round-trip is stable.
@@ -397,19 +398,83 @@ function parseTableCellContent(
 	registry?: SchemaRegistry,
 ): BlockNode[] {
 	const blockRules = registry?.getBlockParseRules() ?? [];
-	const cellBlocks: BlockNode[] = [];
+	const cellBlocks: BlockNode[] = parseBlockContainerChildren(
+		cellEl,
+		blockRules,
+		adoptedIds,
+		registry,
+	);
 
-	for (const child of Array.from(cellEl.childNodes)) {
-		parseChildNode(child, cellBlocks, blockRules, adoptedIds, registry);
-	}
-
-	// No blocks produced: treat entire cell content as one paragraph
+	// No blocks produced: treat the cell as one empty paragraph.
 	if (cellBlocks.length === 0) {
-		const inlineContent = parseElementToInlineContent(cellEl, registry);
-		cellBlocks.push(createBlockNode(nodeType('paragraph'), inlineContent));
+		cellBlocks.push(createBlockNode(nodeType('paragraph'), [createTextNode('')]));
 	}
 
 	return cellBlocks;
+}
+
+type BlockParseRules = readonly { readonly rule: ParseRule; readonly type: string }[];
+
+/**
+ * Parses the children of a block container (blockquote, table cell) into block
+ * nodes. Consecutive inline content (text nodes and inline elements such as
+ * `<em>`, `<strong>`, `<a>`) is coalesced into a single paragraph with its marks
+ * intact, while genuine block children (paragraphs, headings, lists, tables,
+ * nested blockquotes) are parsed recursively. This preserves the common quote
+ * shape that mixes text with inline marks as one paragraph (issue #141).
+ */
+function parseBlockContainerChildren(
+	el: HTMLElement,
+	blockRules: BlockParseRules,
+	adoptedIds: Set<string>,
+	registry?: SchemaRegistry,
+): BlockNode[] {
+	const blocks: BlockNode[] = [];
+	let inlineRun: ChildNode[] = [];
+
+	const flushInlineRun = (): void => {
+		if (inlineRunHasContent(inlineRun)) {
+			blocks.push(
+				createBlockNode(nodeType('paragraph'), parseNodesToInlineContent(inlineRun, registry)),
+			);
+		}
+		inlineRun = [];
+	};
+
+	for (const child of Array.from(el.childNodes)) {
+		if (isBlockLevelChild(child, blockRules)) {
+			flushInlineRun();
+			parseChildNode(child, blocks, blockRules, adoptedIds, registry);
+		} else {
+			inlineRun.push(child);
+		}
+	}
+	flushInlineRun();
+
+	return blocks;
+}
+
+/**
+ * Whether a child node is block-level content. Known container tags (lists,
+ * tables, nested blockquotes) and any element matching a block parse rule
+ * (paragraphs, headings, code blocks, ...) are block-level; text nodes and
+ * inline elements (`<em>`, `<a>`, `<br>`, ...) are not.
+ */
+function isBlockLevelChild(node: ChildNode, blockRules: BlockParseRules): boolean {
+	if (node.nodeType !== Node.ELEMENT_NODE) return false;
+	const el = node as HTMLElement;
+	const tag: string = el.tagName.toLowerCase();
+	if (tag === 'ul' || tag === 'ol' || tag === 'table' || tag === 'blockquote') return true;
+	return matchBlockParseRule(el, blockRules) !== null;
+}
+
+/** Whether an inline run carries meaningful content (non-whitespace text or any element). */
+function inlineRunHasContent(nodes: readonly ChildNode[]): boolean {
+	for (const node of nodes) {
+		if (node.nodeType === Node.ELEMENT_NODE) return true;
+		if (node.nodeType === Node.TEXT_NODE && node.textContent?.trim()) return true;
+	}
+	return false;
 }
 
 /**
@@ -421,10 +486,26 @@ function parseElementToInlineContent(
 	registry?: SchemaRegistry,
 	skipNestedLists?: boolean,
 ): (TextNode | InlineNode)[] {
+	return parseNodesToInlineContent([el], registry, skipNestedLists);
+}
+
+/**
+ * Walks a list of sibling DOM nodes into inline content, applying mark and
+ * inline-node parse rules. Each node is walked from an empty mark set, so a run
+ * mixing text and inline elements (e.g. `text <em>x</em> end`) coalesces into a
+ * single inline sequence with marks preserved on the styled run.
+ */
+function parseNodesToInlineContent(
+	nodes: readonly ChildNode[],
+	registry?: SchemaRegistry,
+	skipNestedLists?: boolean,
+): (TextNode | InlineNode)[] {
 	const result: (TextNode | InlineNode)[] = [];
 	const markRules = registry?.getMarkParseRules() ?? [];
 	const inlineRules = registry?.getInlineParseRules() ?? [];
-	walkElement(el, [], result, markRules, inlineRules, skipNestedLists);
+	for (const node of nodes) {
+		walkElement(node, [], result, markRules, inlineRules, skipNestedLists);
+	}
 
 	// A lone <br> as the only content of a block is a placeholder for an empty
 	// paragraph (e.g. `<p><br></p>`), not a real hard break. Normalize to empty text.


### PR DESCRIPTION
## Summary

Fixes two open bugs verified against the current codebase.

### #141 — Blockquote parser fragments mixed inline content (regression from #136)
`parseBlockquoteElement` / `parseTableCellContent` looped `parseChildNode` per child, turning every text node and inline element into its own paragraph, so a quote mixing text with marks (`<blockquote>This is a <em>great</em> quote.</blockquote>`) fragmented into three paragraphs.

- New shared `parseBlockContainerChildren` coalesces consecutive inline content (text + `<em>`/`<strong>`/`<a>`/…) into a single paragraph with marks intact, while parsing genuine block children (paragraphs, headings, lists, tables, nested blockquotes) recursively.
- `parseElementToInlineContent` now delegates to `parseNodesToInlineContent([el])` (behavior-identical) so a run of sibling nodes can be walked from an empty mark set without dropping marks on top-level inline fallbacks.
- Applied to both blockquotes and table cells (same latent bug, DRY).

### #144 — Font-size listbox double key handling
The combobox keydown handlers called `preventDefault` but not `stopPropagation`, so the toolbar's generic popup handler re-processed the same event and advanced focus a second time. The popup now owns its keyboard model via a `consume()` helper that claims handled keys.

## Tests
- Parser: mixed inline → one paragraph, italic + link(href) marks preserved, surrounding text unmarked, block children still nested, direct + blockquote-in table cells, empty quote.
- Font-size: unit propagation tests + an e2e asserting real DOM focus advances by exactly one preset.
- All regression tests verified to fail without the fix (revert/rebuild cycle).
- 4084 unit tests, relevant e2e, lint and typecheck all green.

Fixes #141
Fixes #144