### PR TITLE
fix: consume empty paragraph when inserting block objects (#152)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.2.0] - 2026-06-06
+## [Unreleased]
+
+### Fixed
+
+- **Inserting a block object on an empty line no longer leaves a stray empty paragraph above it (#152)** — Inserting a table, horizontal rule, image, or display formula while the cursor sat in an empty paragraph did not consume that paragraph: the object was inserted after it, leaving a blank line above (`[paragraph, table, paragraph]` instead of `[table, paragraph]`), and the blank lines accumulated in longer documents. The four insert commands each hand-rolled their own placement logic; they now route through a single shared `insertBlockObjectOnOwnLine` primitive (`commands/BlockInsertion.ts`) that resolves the top-level ancestor of the selection, inserts the object followed by a trailing paragraph, and consumes the anchor when it is a blank-line paragraph. The emptiness test is inline-aware (it counts inline atoms as width 1), so a paragraph holding only an inline node such as an inline formula is never deleted; it is deliberately stricter than the paste pipeline's helper (paragraph-only, not any empty non-void block). A side effect of routing through top-level-ancestor resolution: inserting a horizontal rule or image with the cursor inside a container (e.g. a blockquote) now escapes to the document root, consistent with table and display-formula insertion, instead of failing. Covered by new unit tests (including a content-loss guard for the inline-node case) and the e2e regression suite.
 
 ### Added
 

--- a/packages/core/src/commands/BlockInsertion.ts
+++ b/packages/core/src/commands/BlockInsertion.ts
@@ -1,9 +1,11 @@
 /**
- * Block insertion utilities for paste and clipboard operations.
+ * Block insertion utilities for paste/clipboard operations and block-object
+ * commands (table, image, horizontal rule, display formula).
  *
  * Provides context resolution (parent path, anchor index, empty detection)
  * for inserting blocks into the document tree — both at root level and
- * inside table cells. Also contains pure helpers for block cloning,
+ * inside table cells — plus the shared primitive that drops a block-level
+ * object onto its own line. Also contains pure helpers for block cloning,
  * recursive lookup, and attribute sanitization against a NodeSpec.
  */
 
@@ -18,6 +20,7 @@ import {
 	createInlineNode,
 	createTextNode,
 	generateBlockId,
+	getBlockLength,
 	getBlockText,
 	isBlockNode,
 } from '../model/Document.js';
@@ -162,6 +165,66 @@ export function insertBlockAfterAnchor(
 	}
 
 	return true;
+}
+
+/**
+ * Document-root index of the top-level block that contains `blockId` — the block
+ * itself when it already lives at the document root. Returns -1 when the block is
+ * not part of the document. Block-level objects always live at the root, so an
+ * insertion triggered from inside a container (e.g. a table cell) escapes to the
+ * top level via this lookup.
+ */
+export function topLevelBlockIndex(state: EditorState, blockId: BlockId): number {
+	const path: readonly string[] | undefined = findNodePath(state.doc, blockId);
+	const topId: BlockId = path && path.length > 0 ? (path[0] as BlockId) : blockId;
+	return state.doc.children.findIndex((b) => b.id === topId);
+}
+
+/**
+ * True when the block is a blank-line paragraph. Inline-aware: a paragraph that
+ * holds only an atomic inline node (e.g. an inline formula) has width > 0 and is
+ * therefore never treated as blank, so it is never silently removed.
+ */
+function isEmptyParagraph(block: BlockNode): boolean {
+	return block.type === 'paragraph' && getBlockLength(block) === 0;
+}
+
+/**
+ * Places a block-level object on its own line at the document root: the object
+ * followed by a trailing empty paragraph, so a void/atomic object always has an
+ * editable line after it. The object is inserted after the top-level ancestor of
+ * the current selection; when that ancestor is a blank-line paragraph it is
+ * consumed, so the object is never preceded by a stray empty paragraph (#152).
+ *
+ * Only an empty *paragraph* is consumed — an empty heading or list item is
+ * deliberate structure — and the emptiness test is inline-aware (see
+ * {@link isEmptyParagraph}). This is intentionally stricter than
+ * {@link insertBlockAfterAnchor}, which the paste pipeline uses with a text-only
+ * emptiness notion.
+ *
+ * Selection is the caller's concern, since objects differ (a cursor inside a new
+ * table vs. a node selection on an image or display formula). Returns the
+ * appended trailing paragraph, or undefined when the selection has no resolvable
+ * anchor.
+ */
+export function insertBlockObjectOnOwnLine(
+	state: EditorState,
+	builder: TransactionBuilder,
+	anchorBlockId: BlockId,
+	object: BlockNode,
+): BlockNode | undefined {
+	const topIndex: number = topLevelBlockIndex(state, anchorBlockId);
+	if (topIndex === -1) return undefined;
+
+	const trailing: BlockNode = createBlockNode(nodeType('paragraph'));
+	builder.insertNode([], topIndex + 1, object).insertNode([], topIndex + 2, trailing);
+
+	const anchor: BlockNode | undefined = state.doc.children[topIndex];
+	if (anchor && isEmptyParagraph(anchor)) {
+		builder.removeNode([], topIndex);
+	}
+
+	return trailing;
 }
 
 /** Recursively clones a block tree, assigning new IDs to all block nodes. */

--- a/packages/core/src/plugins/InsertBlockObjectOnEmptyLine.test.ts
+++ b/packages/core/src/plugins/InsertBlockObjectOnEmptyLine.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Regression test for issue #152 — "Inserting a block object on an empty line
+ * leaves a stray empty paragraph above it".
+ *
+ * Each test inserts a block object (table, horizontal rule, image, display
+ * formula) into a document that is a single empty paragraph and asserts that the
+ * blank line is consumed: the object becomes the first child and is NOT preceded
+ * by an empty paragraph. The leading `children[0]` assertion is the one that
+ * encodes the bug; `toHaveLength(2)` pins the expected `[object, paragraph]`.
+ *
+ * The fix is the shared `insertBlockObjectOnOwnLine` primitive in
+ * `commands/BlockInsertion.ts`, which all four insert paths now route through.
+ *
+ * The final test guards the subtle invariant behind that primitive: the
+ * "blank line" test is inline-aware, so a paragraph holding only an atomic inline
+ * node (e.g. an inline formula) is NOT consumed — collapsing the check back to
+ * `getBlockText() === ''` would silently delete that formula.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { createInlineNode, getBlockLength, getInlineChildren } from '../model/Document.js';
+import { inlineType } from '../model/TypeBrands.js';
+import { pluginHarness, stateBuilder } from '../test/TestUtils.js';
+import { buildInsertDisplayMathTr } from './formula/FormulaCommands.js';
+import { DISPLAY_MATH_TYPE, INLINE_MATH_TYPE } from './formula/FormulaTypes.js';
+import { HorizontalRulePlugin } from './horizontal-rule/HorizontalRulePlugin.js';
+import { ImagePlugin } from './image/ImagePlugin.js';
+import { TablePlugin } from './table/TablePlugin.js';
+
+describe('issue #152 — inserting a block object on an empty line', () => {
+	it('insertTable consumes the empty paragraph (no blank line above the table)', async () => {
+		const state = stateBuilder()
+			.paragraph('', 'b1')
+			.cursor('b1', 0)
+			.schema(['paragraph', 'table', 'table_row', 'table_cell'], ['bold'])
+			.build();
+		const h = await pluginHarness(new TablePlugin(), state);
+
+		h.executeCommand('insertTable');
+
+		const children = h.getState().doc.children;
+		expect(children[0]?.type).toBe('table');
+		expect(children).toHaveLength(2);
+		expect(children[1]?.type).toBe('paragraph');
+	});
+
+	it('insertHorizontalRule consumes the empty paragraph (no blank line above the rule)', async () => {
+		const state = stateBuilder()
+			.paragraph('', 'b1')
+			.cursor('b1', 0)
+			.schema(['paragraph', 'horizontal_rule'], ['bold'])
+			.build();
+		const h = await pluginHarness(new HorizontalRulePlugin(), state);
+
+		h.executeCommand('insertHorizontalRule');
+
+		const children = h.getState().doc.children;
+		expect(children[0]?.type).toBe('horizontal_rule');
+		expect(children).toHaveLength(2);
+		expect(children[1]?.type).toBe('paragraph');
+	});
+
+	it('insertImage consumes the empty paragraph (no blank line above the image)', async () => {
+		const state = stateBuilder()
+			.paragraph('', 'b1')
+			.cursor('b1', 0)
+			.schema(['paragraph', 'image'], ['bold'])
+			.build();
+		const h = await pluginHarness(new ImagePlugin(), state);
+
+		h.executeCommand('insertImage');
+
+		const children = h.getState().doc.children;
+		expect(children[0]?.type).toBe('image');
+		expect(children).toHaveLength(2);
+		expect(children[1]?.type).toBe('paragraph');
+	});
+
+	it('display formula insert consumes the empty paragraph (no blank line above the formula)', async () => {
+		const state = stateBuilder()
+			.paragraph('', 'b1')
+			.cursor('b1', 0)
+			.schema(['paragraph', DISPLAY_MATH_TYPE], ['bold'])
+			.build();
+
+		const tr = buildInsertDisplayMathTr(state, {
+			mathml: '<math><mn>1</mn></math>',
+			latex: '1',
+			alt: 'one',
+			fontSize: '',
+		});
+		expect(tr).not.toBeNull();
+		if (!tr) return;
+
+		const children = state.apply(tr).doc.children;
+		expect(children[0]?.type).toBe(DISPLAY_MATH_TYPE);
+		expect(children).toHaveLength(2);
+		expect(children[1]?.type).toBe('paragraph');
+	});
+
+	it('does NOT consume a paragraph that holds only an inline node (no content loss)', () => {
+		// A paragraph whose only child is an inline formula has an empty getBlockText
+		// but is NOT a blank line — consuming it would silently delete the formula.
+		// The emptiness test must be inline-aware (atoms have width 1), so this anchor
+		// is preserved and the display formula is placed after it.
+		const state = stateBuilder()
+			.blockWithInlines(
+				'paragraph',
+				[
+					createInlineNode(inlineType(INLINE_MATH_TYPE), {
+						mathml: '<math><mi>x</mi></math>',
+						latex: 'x',
+						alt: 'x',
+						fontSize: '',
+					}),
+				],
+				'b1',
+			)
+			.cursor('b1', 1)
+			.schema(['paragraph', DISPLAY_MATH_TYPE], ['bold'])
+			.build();
+
+		const tr = buildInsertDisplayMathTr(state, {
+			mathml: '<math><mn>1</mn></math>',
+			latex: '1',
+			alt: 'one',
+			fontSize: '',
+		});
+		expect(tr).not.toBeNull();
+		if (!tr) return;
+
+		const children = state.apply(tr).doc.children;
+		expect(children).toHaveLength(3);
+		const anchor = children[0];
+		expect(anchor?.type).toBe('paragraph');
+		if (!anchor) return;
+		expect(getInlineChildren(anchor)).toHaveLength(1);
+		expect(getBlockLength(anchor)).toBe(1);
+		expect(children[1]?.type).toBe(DISPLAY_MATH_TYPE);
+	});
+});

--- a/packages/core/src/plugins/formula/FormulaCommands.ts
+++ b/packages/core/src/plugins/formula/FormulaCommands.ts
@@ -5,6 +5,7 @@
  * free from the transaction system.
  */
 
+import { insertBlockObjectOnOwnLine } from '../../commands/BlockInsertion.js';
 import { resolveInsertPoint } from '../../commands/CommandHelpers.js';
 import { addDeleteSelectionSteps } from '../../commands/Commands.js';
 import { createBlockNode, createInlineNode } from '../../model/Document.js';
@@ -74,7 +75,7 @@ export function appendDisplayMathSteps(
 		.setSelection(createNodeSelection(block.id, []));
 }
 
-/** Builds a transaction inserting a display math block after the current top-level block. */
+/** Builds a transaction placing a display math block on its own line at the cursor. */
 export function buildInsertDisplayMathTr(
 	state: EditorState,
 	attrs: FormulaAttrs,
@@ -82,14 +83,12 @@ export function buildInsertDisplayMathTr(
 	const anchorId: BlockId | undefined = getSelectedBlockId(state);
 	if (!anchorId) return null;
 
-	// Display equations live at the top level; anchor on the top-level ancestor.
-	const path: readonly BlockId[] | undefined = state.getNodePath(anchorId);
-	const topId: BlockId = path && path.length > 0 ? (path[0] as BlockId) : anchorId;
-	const topIndex: number = state.doc.children.findIndex((b) => b.id === topId);
-	const insertAt: number = topIndex === -1 ? state.doc.children.length : topIndex + 1;
-
+	const block = createBlockNode(nodeType(DISPLAY_MATH_TYPE), [], undefined, toNodeAttrs(attrs));
 	const builder: TransactionBuilder = state.transaction('command');
-	appendDisplayMathSteps(builder, insertAt, attrs);
+	const trailing = insertBlockObjectOnOwnLine(state, builder, anchorId, block);
+	if (!trailing) return null;
+
+	builder.setSelection(createNodeSelection(block.id, []));
 	return builder.build();
 }
 

--- a/packages/core/src/plugins/horizontal-rule/HorizontalRulePlugin.ts
+++ b/packages/core/src/plugins/horizontal-rule/HorizontalRulePlugin.ts
@@ -3,6 +3,7 @@
  * with NodeSpec, insert command, input rule, keyboard shortcut, and toolbar button.
  */
 
+import { insertBlockObjectOnOwnLine } from '../../commands/BlockInsertion.js';
 import { createBlockNode } from '../../model/Document.js';
 import { createCollapsedSelection, isCollapsed, isTextSelection } from '../../model/Selection.js';
 import { nodeType } from '../../model/TypeBrands.js';
@@ -147,21 +148,20 @@ export class HorizontalRulePlugin implements Plugin {
 	 */
 	private insertHorizontalRule(context: PluginContext): boolean {
 		const state: EditorState = context.getState();
-		if (!isTextSelection(state.selection)) return false;
-		const blockIndex: number = findBlockIndexForCursor(state);
-		if (blockIndex === -1) return false;
+		const sel = state.selection;
+		if (!isTextSelection(sel)) return false;
 
-		const hrBlock = createBlockNode(nodeType('horizontal_rule'));
-		const newParagraph = createBlockNode(nodeType('paragraph'));
+		const builder = state.transaction('command');
+		const trailing = insertBlockObjectOnOwnLine(
+			state,
+			builder,
+			sel.anchor.blockId,
+			createBlockNode(nodeType('horizontal_rule')),
+		);
+		if (!trailing) return false;
 
-		const tr = state
-			.transaction('command')
-			.insertNode([], blockIndex + 1, hrBlock)
-			.insertNode([], blockIndex + 2, newParagraph)
-			.setSelection(createCollapsedSelection(newParagraph.id, 0))
-			.build();
-
-		context.dispatch(tr);
+		builder.setSelection(createCollapsedSelection(trailing.id, 0));
+		context.dispatch(builder.build());
 		return true;
 	}
 }

--- a/packages/core/src/plugins/image/ImageCommands.test.ts
+++ b/packages/core/src/plugins/image/ImageCommands.test.ts
@@ -98,7 +98,10 @@ describe('ImageCommands', () => {
 			pm.executeCommand('insertImage');
 
 			const doc = getState().doc;
-			expect(doc.children[2]?.type).toBe('paragraph');
+			// The empty paragraph is consumed (#152): [image, trailing paragraph].
+			expect(doc.children).toHaveLength(2);
+			expect(doc.children[0]?.type).toBe('image');
+			expect(doc.children[1]?.type).toBe('paragraph');
 		});
 
 		it('sets NodeSelection on the new image block', async () => {
@@ -115,7 +118,8 @@ describe('ImageCommands', () => {
 			const sel = getState().selection;
 			expect(isNodeSelection(sel)).toBe(true);
 			if (isNodeSelection(sel)) {
-				expect(sel.nodeId).toBe(getState().doc.children[1]?.id);
+				// Empty paragraph consumed (#152): the image is the first block.
+				expect(sel.nodeId).toBe(getState().doc.children[0]?.id);
 			}
 		});
 

--- a/packages/core/src/plugins/image/ImageCommands.ts
+++ b/packages/core/src/plugins/image/ImageCommands.ts
@@ -3,6 +3,7 @@
  * Supports both root-level and nested contexts (e.g. images inside table cells).
  */
 
+import { insertBlockObjectOnOwnLine } from '../../commands/BlockInsertion.js';
 import { deleteNodeSelection } from '../../commands/NodeSelectionCommands.js';
 import type { BlockAttrs, BlockNode } from '../../model/Document.js';
 import { createBlockNode, getBlockChildren, isBlockNode } from '../../model/Document.js';
@@ -61,27 +62,20 @@ function findTableCellAncestor(state: EditorState, bid: BlockId): BlockId | unde
 	return undefined;
 }
 
-/** Inserts an image at document root after the anchor block. */
+/** Inserts an image on its own line at document root, after the anchor block. */
 function insertImageAtRoot(
 	state: EditorState,
 	context: PluginContext,
 	anchorBlockId: BlockId,
 	imageAttrs: BlockAttrs,
 ): boolean {
-	const blockIndex: number = state.doc.children.findIndex((b) => b.id === anchorBlockId);
-	if (blockIndex === -1) return false;
-
 	const imageBlock: BlockNode = createBlockNode(nodeType('image'), [], undefined, imageAttrs);
-	const newParagraph: BlockNode = createBlockNode(nodeType('paragraph'));
+	const builder = state.transaction('command');
+	const trailing = insertBlockObjectOnOwnLine(state, builder, anchorBlockId, imageBlock);
+	if (!trailing) return false;
 
-	const tr = state
-		.transaction('command')
-		.insertNode([], blockIndex + 1, imageBlock)
-		.insertNode([], blockIndex + 2, newParagraph)
-		.setSelection(createNodeSelection(imageBlock.id, []))
-		.build();
-
-	context.dispatch(tr);
+	builder.setSelection(createNodeSelection(imageBlock.id, []));
+	context.dispatch(builder.build());
 	return true;
 }
 

--- a/packages/core/src/plugins/table/TableCommands.ts
+++ b/packages/core/src/plugins/table/TableCommands.ts
@@ -7,13 +7,9 @@
  * by both commands (via PluginContext) and controls (via getState/dispatch).
  */
 
+import { insertBlockObjectOnOwnLine } from '../../commands/BlockInsertion.js';
 import { createSelectionForBlockBoundary } from '../../commands/CommandHelpers.js';
-import {
-	createBlockNode,
-	createEmptyParagraph,
-	generateBlockId,
-	getBlockChildren,
-} from '../../model/Document.js';
+import { createEmptyParagraph, generateBlockId, getBlockChildren } from '../../model/Document.js';
 import {
 	createCollapsedSelection,
 	createNodeSelection,
@@ -21,8 +17,7 @@ import {
 	isNodeSelection,
 	isTextSelection,
 } from '../../model/Selection.js';
-import type { BlockId, NodeTypeName } from '../../model/TypeBrands.js';
-import { nodeType } from '../../model/TypeBrands.js';
+import type { BlockId } from '../../model/TypeBrands.js';
 import type { EditorState } from '../../state/EditorState.js';
 import type { Transaction } from '../../state/Transaction.js';
 import type { PluginContext } from '../Plugin.js';
@@ -218,36 +213,10 @@ export function insertTable(context: PluginContext, rows: number, cols: number):
 	const sel = state.selection;
 	if (!isTextSelection(sel)) return false;
 
-	const currentBlockId: BlockId = sel.anchor.blockId;
-
-	// Find which root-level block contains the current selection
-	let rootIndex = -1;
-	for (let i = 0; i < state.doc.children.length; i++) {
-		const rootBlock = state.doc.children[i];
-		if (!rootBlock) continue;
-		if (rootBlock.id === currentBlockId) {
-			rootIndex = i;
-			break;
-		}
-		// Check if current block is nested inside this root block
-		const path = state.getNodePath(currentBlockId);
-		if (path && path[0] === rootBlock.id) {
-			rootIndex = i;
-			break;
-		}
-	}
-
-	if (rootIndex === -1) rootIndex = state.doc.children.length - 1;
-
 	const tableNode = createTable(rows, cols);
-	const paragraphAfter = createBlockNode(nodeType('paragraph') as NodeTypeName);
-
-	// Insert table after current block, then paragraph after table
-	const insertIndex: number = rootIndex + 1;
-	const tr = state
-		.transaction('command')
-		.insertNode([], insertIndex, tableNode)
-		.insertNode([], insertIndex + 1, paragraphAfter);
+	const builder = state.transaction('command');
+	const trailing = insertBlockObjectOnOwnLine(state, builder, sel.anchor.blockId, tableNode);
+	if (!trailing) return false;
 
 	// Set cursor in first paragraph inside first cell
 	const firstRow = getBlockChildren(tableNode)[0];
@@ -255,12 +224,12 @@ export function insertTable(context: PluginContext, rows: number, cols: number):
 	const firstParagraph = firstCell ? getBlockChildren(firstCell)[0] : undefined;
 
 	if (firstParagraph) {
-		tr.setSelection(createCollapsedSelection(firstParagraph.id, 0));
+		builder.setSelection(createCollapsedSelection(firstParagraph.id, 0));
 	} else if (firstCell) {
-		tr.setSelection(createCollapsedSelection(firstCell.id, 0));
+		builder.setSelection(createCollapsedSelection(firstCell.id, 0));
 	}
 
-	context.dispatch(tr.build());
+	context.dispatch(builder.build());
 	return true;
 }
 

--- a/packages/core/src/plugins/table/TablePlugin.test.ts
+++ b/packages/core/src/plugins/table/TablePlugin.test.ts
@@ -373,7 +373,8 @@ describe('Table insertTable command', () => {
 		h.executeCommand('insertTable');
 
 		const newState = h.getState();
-		const table = newState.doc.children[1];
+		// The empty paragraph is consumed (#152), so the table is the first block.
+		const table = newState.doc.children[0];
 		const firstRow = getBlockChildren(table)[0];
 		const firstCell = getBlockChildren(firstRow)[0];
 		const firstParagraph = getBlockChildren(firstCell)[0];


### PR DESCRIPTION
## Summary

Fixes #152. Inserting a **table, horizontal rule, image, or display formula** while the cursor was in an empty paragraph left that paragraph above the object, producing a stray blank line (`[paragraph, table, paragraph]` instead of `[table, paragraph]`). In longer documents the blank lines accumulated.

## Root cause

The four insert commands each hand-rolled their own block-placement logic, and none consumed the empty line the object was placed on.

## Fix

A single shared primitive `insertBlockObjectOnOwnLine` in `commands/BlockInsertion.ts` that all four insert paths now route through. It:

- resolves the top-level ancestor of the selection,
- inserts the object followed by a trailing paragraph,
- consumes the anchor when it is a blank-line paragraph.

The emptiness test is **inline-aware** (`getBlockLength === 0`, counting inline atoms as width 1), so a paragraph holding only an inline node (e.g. an inline formula) is never deleted. It is deliberately stricter than the paste pipeline's helper (paragraph-only, not any empty non-void block).

**Side effect (intentional):** inserting a horizontal rule or image with the cursor inside a container (e.g. a blockquote) now escapes to the document root, consistent with table and display-formula insertion, instead of returning `false`.

## Scope

This fixes the issue's primary defect (the stray paragraph **above** the object). The double trailing paragraph after a display-formula→image sequence mentioned in the issue Notes is a separate mechanism (the formula insert leaves a node selection plus its own trailing paragraph) and is tracked as a follow-up, not bundled here.

## Tests

- New `packages/core/src/plugins/InsertBlockObjectOnEmptyLine.test.ts` (5 cases, including a content-loss guard for the inline-node case).
- Updated three tests that pinned the old layout.
- Gates: 4175 unit tests, lint, typecheck, chromium e2e (483 passed) all green.

Closes #152

🤖 Generated with [Claude Code](https://claude.com/claude-code)