### PR TITLE
test: make ReDoS-resistance timing guards robust under parallel load

### DIFF
--- a/packages/core/src/model/HTMLUtils.test.ts
+++ b/packages/core/src/model/HTMLUtils.test.ts
@@ -1,6 +1,14 @@
 import { describe, expect, it } from 'vitest';
 import { SAFE_URI_REGEXP, escapeAttr, escapeHTML, formatHTML, sanitizeHref } from './HTMLUtils.js';
 
+/**
+ * Wall-clock ceiling for the ReDoS-resistance checks below. Catastrophic
+ * backtracking takes seconds, so a one-second ceiling separates linear
+ * formatting (well under a millisecond) from a regression while staying robust
+ * to CPU contention when the full suite runs in parallel. Not a micro-benchmark.
+ */
+const REDOS_CEILING_MS = 1000;
+
 describe('SAFE_URI_REGEXP', () => {
 	it('allows blob: URIs', () => {
 		expect(SAFE_URI_REGEXP.test('blob:http://localhost/abc-123')).toBe(true);
@@ -106,7 +114,7 @@ describe('formatHTML ReDoS resistance', () => {
 		const start: number = performance.now();
 		formatHTML(malicious);
 		const elapsed: number = performance.now() - start;
-		expect(elapsed).toBeLessThan(100);
+		expect(elapsed).toBeLessThan(REDOS_CEILING_MS);
 	});
 
 	it('completes in reasonable time with repeated slashes', () => {
@@ -114,7 +122,7 @@ describe('formatHTML ReDoS resistance', () => {
 		const start: number = performance.now();
 		formatHTML(malicious);
 		const elapsed: number = performance.now() - start;
-		expect(elapsed).toBeLessThan(100);
+		expect(elapsed).toBeLessThan(REDOS_CEILING_MS);
 	});
 });
 

--- a/packages/core/src/plugins/smart-paste/detectors/LexerDetector.test.ts
+++ b/packages/core/src/plugins/smart-paste/detectors/LexerDetector.test.ts
@@ -10,6 +10,14 @@ import { LexerDetector } from './LexerDetector.js';
 const javaDetector: ContentDetector = JAVA_SUPPORT.detection as ContentDetector;
 const typescriptDetector: ContentDetector = TYPESCRIPT_SUPPORT.detection as ContentDetector;
 
+/**
+ * Wall-clock ceiling for the ReDoS-resistance check. Catastrophic backtracking
+ * on a 50k-character input takes seconds, so a one-second ceiling separates
+ * linear scanning (tens of ms) from a regression while staying robust to CPU
+ * contention when the full suite runs in parallel.
+ */
+const REDOS_CEILING_MS = 1000;
+
 function detectBoth(text: string): { java: DetectionResult | null; ts: DetectionResult | null } {
 	return {
 		java: javaDetector.detect(text),
@@ -212,14 +220,18 @@ describe('LexerDetector', () => {
 	});
 
 	describe('ReDoS resistance', () => {
-		it('handles 50k whitespace runs in under 150ms', () => {
+		it('handles 50k whitespace runs without catastrophic backtracking', () => {
 			const input: string = `interface${' '.repeat(50_000)}\nfoo`;
 
 			const start: number = performance.now();
 			typescriptDetector.detect(input);
 			const elapsed: number = performance.now() - start;
 
-			expect(elapsed).toBeLessThan(150);
+			// Linear scanning finishes in tens of milliseconds; this is a ReDoS
+			// guard, so the ceiling only needs to sit far below the seconds that
+			// catastrophic backtracking would take. Kept generous so it never flakes
+			// under parallel CPU load — it is not a micro-benchmark.
+			expect(elapsed).toBeLessThan(REDOS_CEILING_MS);
 		});
 
 		it('returns null beyond the default 100k length cap', () => {


### PR DESCRIPTION
## Summary

Three ReDoS-resistance tests asserted a tight wall-clock budget (150ms in `LexerDetector`, 100ms in `HTMLUtils`) that flaked when the full suite ran in parallel and saturated the CPU. The `LexerDetector` check hit 400ms under load while finishing in ~46ms in isolation.

These budgets exist to catch catastrophic backtracking, which takes seconds on the pathological inputs, not to micro-benchmark linear scanning. This raises all three to a shared, documented `REDOS_CEILING_MS` of 1000ms, which still cleanly separates linear from exponential behaviour while staying robust to CPU contention. The `LexerDetector` test was renamed so its name no longer pins a brittle number.

## Context

This commit (`9c85fad`) was made on the `fix/...173` branch after PR #174 was already merged, so it never reached `main`. It is unrelated to issue #173 itself and is split out here as its own change.

## Changes

- `packages/core/src/model/HTMLUtils.test.ts`
- `packages/core/src/plugins/smart-paste/detectors/LexerDetector.test.ts`

## Test plan

- [x] `pnpm --filter @notectl/core test -- LexerDetector HTMLUtils` (69 passed)