### PR TITLE
fix(alignment): apply alignment to all blocks in a multi-block selection

### DIFF
--- a/packages/core/src/plugins/alignment/AlignmentPlugin.test.ts
+++ b/packages/core/src/plugins/alignment/AlignmentPlugin.test.ts
@@ -253,6 +253,42 @@ describe('AlignmentPlugin', () => {
 		});
 	});
 
+	describe('multi-block alignment', () => {
+		it('sets alignment on all blocks in a range selection', async () => {
+			const state = stateBuilder()
+				.paragraph('Hello', 'b1')
+				.paragraph('World', 'b2')
+				.paragraph('Foo', 'b3')
+				.selection({ blockId: 'b1', offset: 0 }, { blockId: 'b3', offset: 3 })
+				.schema(['paragraph', 'heading'], ['bold', 'italic', 'underline'])
+				.build();
+			const h = await pluginHarness(new AlignmentPlugin(), state, HARNESS_OPTIONS);
+
+			h.executeCommand('alignCenter');
+			const doc = h.getState().doc;
+			expect(doc.children[0]?.attrs?.align).toBe('center');
+			expect(doc.children[1]?.attrs?.align).toBe('center');
+			expect(doc.children[2]?.attrs?.align).toBe('center');
+		});
+
+		it('only changes alignable blocks in a range selection', async () => {
+			const state = stateBuilder()
+				.paragraph('Hello', 'b1')
+				.block('list_item', 'Item', 'b2', { attrs: { listType: 'bullet', indent: 0 } })
+				.paragraph('World', 'b3')
+				.selection({ blockId: 'b1', offset: 0 }, { blockId: 'b3', offset: 5 })
+				.schema(['paragraph', 'heading', 'list_item'], ['bold', 'italic', 'underline'])
+				.build();
+			const h = await pluginHarness(new AlignmentPlugin(), state, HARNESS_OPTIONS);
+
+			h.executeCommand('alignEnd');
+			const doc = h.getState().doc;
+			expect(doc.children[0]?.attrs?.align).toBe('end');
+			expect(doc.children[1]?.attrs?.align).toBeUndefined();
+			expect(doc.children[2]?.attrs?.align).toBe('end');
+		});
+	});
+
 	describe('NodeSelection support', () => {
 		it('sets alignment on image via NodeSelection', async () => {
 			const state = stateBuilder()

--- a/packages/core/src/plugins/alignment/AlignmentPlugin.ts
+++ b/packages/core/src/plugins/alignment/AlignmentPlugin.ts
@@ -16,8 +16,9 @@ import type { Plugin, PluginContext } from '../Plugin.js';
 import { patchNodeSpecAttr } from '../shared/NodeSpecPatching.js';
 import {
 	capitalize,
+	dispatchIfPresent,
 	getSelectedBlock,
-	getSelectedBlockId,
+	getSelectedBlockIds,
 	resolveLocale,
 } from '../shared/PluginHelpers.js';
 import {
@@ -206,27 +207,33 @@ export class AlignmentPlugin implements Plugin {
 
 	// --- Alignment Logic ---
 
+	/**
+	 * Applies `alignment` to every alignable block in the current selection in
+	 * a single transaction. A multi-block selection aligns all of its blocks,
+	 * not just the anchor; non-alignable blocks in the range are left untouched.
+	 */
 	private setAlignment(context: PluginContext, alignment: BlockAlignment): boolean {
 		const state = context.getState();
-		const block = getSelectedBlock(state);
-		if (!block || !this.alignableTypes.has(block.type)) return false;
+		const blockIds: BlockId[] = getSelectedBlockIds(state);
+		if (blockIds.length === 0) return false;
 
-		const id = getSelectedBlockId(state);
-		if (!id) return false;
+		const tb = state.transaction('command');
+		let changed = false;
 
-		const path = state.getNodePath(id);
-		if (!path) return false;
+		for (const id of blockIds) {
+			const block = state.getBlock(id);
+			if (!block || !this.alignableTypes.has(block.type)) continue;
 
-		const newAttrs = { ...block.attrs, align: alignment };
+			const path = state.getNodePath(id);
+			if (!path) continue;
 
-		const tr = state
-			.transaction('command')
-			.setNodeAttr(path as BlockId[], newAttrs)
-			.setSelection(state.selection)
-			.build();
+			tb.setNodeAttr(path, { ...block.attrs, align: alignment });
+			changed = true;
+		}
 
-		context.dispatch(tr);
-		return true;
+		if (!changed) return false;
+
+		return dispatchIfPresent(context, tb.setSelection(state.selection).build());
 	}
 
 	private isNonDefaultAlignment(state: EditorState): boolean {

--- a/packages/core/src/plugins/shared/PluginHelpers.ts
+++ b/packages/core/src/plugins/shared/PluginHelpers.ts
@@ -64,3 +64,30 @@ export function getSelectedBlockId(state: EditorState): BlockId | undefined {
 	if (isTextSelection(sel)) return sel.anchor.blockId;
 	return undefined;
 }
+
+/**
+ * Returns every leaf-block ID covered by the current selection, in document
+ * order. A NodeSelection yields its single node; a collapsed or single-block
+ * TextSelection yields one ID; a multi-block TextSelection yields the full
+ * inclusive range from anchor to head. Used by block-attribute commands
+ * (alignment, text direction) that must apply to the whole selection.
+ */
+export function getSelectedBlockIds(state: EditorState): BlockId[] {
+	const sel = state.selection;
+
+	if (isNodeSelection(sel)) return [sel.nodeId];
+	if (!isTextSelection(sel)) return [];
+
+	const anchorId: BlockId = sel.anchor.blockId;
+	const headId: BlockId = sel.head.blockId;
+	if (anchorId === headId) return [anchorId];
+
+	const order: readonly BlockId[] = state.getBlockOrder();
+	const anchorIdx: number = order.indexOf(anchorId);
+	const headIdx: number = order.indexOf(headId);
+	if (anchorIdx === -1 || headIdx === -1) return [];
+
+	const from: number = Math.min(anchorIdx, headIdx);
+	const to: number = Math.max(anchorIdx, headIdx);
+	return order.slice(from, to + 1) as BlockId[];
+}

--- a/packages/core/src/plugins/text-direction/TextDirectionPlugin.ts
+++ b/packages/core/src/plugins/text-direction/TextDirectionPlugin.ts
@@ -13,13 +13,17 @@
  */
 
 import type { BlockNode } from '../../model/Document.js';
-import { isNodeSelection, isTextSelection } from '../../model/Selection.js';
 import type { BlockId } from '../../model/TypeBrands.js';
 import { isMac } from '../../platform/Platform.js';
 import type { EditorState } from '../../state/EditorState.js';
 import type { Plugin, PluginContext } from '../Plugin.js';
 import { patchNodeSpecAttr } from '../shared/NodeSpecPatching.js';
-import { dispatchIfPresent, getSelectedBlock, resolveLocale } from '../shared/PluginHelpers.js';
+import {
+	dispatchIfPresent,
+	getSelectedBlock,
+	getSelectedBlockIds,
+	resolveLocale,
+} from '../shared/PluginHelpers.js';
 import { formatShortcut } from '../shared/ShortcutFormatting.js';
 import { getBlockDir } from './DirectionDetection.js';
 import { DIRECTION_ICONS } from './DirectionIcons.js';
@@ -190,7 +194,7 @@ export class TextDirectionPlugin implements Plugin {
 
 	private setDirection(context: PluginContext, direction: TextDirection): boolean {
 		const state = context.getState();
-		const blockIds: BlockId[] = this.getSelectedBlockIds(state);
+		const blockIds: BlockId[] = getSelectedBlockIds(state);
 		if (blockIds.length === 0) return false;
 
 		const tb = state.transaction('command');
@@ -210,30 +214,6 @@ export class TextDirectionPlugin implements Plugin {
 		if (!changed) return false;
 
 		return dispatchIfPresent(context, tb.setSelection(state.selection).build());
-	}
-
-	private getSelectedBlockIds(state: EditorState): BlockId[] {
-		const sel = state.selection;
-
-		if (isNodeSelection(sel)) {
-			return [sel.nodeId];
-		}
-
-		if (!isTextSelection(sel)) return [];
-
-		const anchorId: BlockId = sel.anchor.blockId;
-		const headId: BlockId = sel.head.blockId;
-
-		if (anchorId === headId) return [anchorId];
-
-		const order: readonly BlockId[] = state.getBlockOrder();
-		const anchorIdx: number = order.indexOf(anchorId);
-		const headIdx: number = order.indexOf(headId);
-		if (anchorIdx === -1 || headIdx === -1) return [];
-
-		const from: number = Math.min(anchorIdx, headIdx);
-		const to: number = Math.max(anchorIdx, headIdx);
-		return order.slice(from, to + 1) as BlockId[];
 	}
 
 	private isNonDefaultDirection(state: EditorState): boolean {


### PR DESCRIPTION
## Summary

Closes #190.

Choosing a text alignment with several blocks selected aligned only the anchor block and silently ignored the rest. `TextDirectionPlugin` already handled the full range correctly, which confirmed this was incomplete behavior rather than a design choice.

## Root cause

`AlignmentPlugin.setAlignment` resolved a single block (`getSelectedBlock` + `getSelectedBlockId`) and applied `align` only to that anchor.

## Fix

Rather than duplicating text-direction's range logic into alignment (which would let the two diverge again), the shared logic is extracted so both plugins run one code path:

- **`PluginHelpers.ts`** — new exported `getSelectedBlockIds(state)`: returns every leaf-block ID covered by the selection (NodeSelection → its node; single/collapsed → one ID; multi-block → the full inclusive anchor→head range in document order).
- **`TextDirectionPlugin.ts`** — deletes its private duplicate and consumes the shared helper.
- **`AlignmentPlugin.ts`** — `setAlignment` now iterates every selected block, applies `align` to each alignable one (skipping non-alignable blocks), and commits a single transaction.

Toolbar `isActive`/`isEnabled` are intentionally left checking the anchor only, matching text-direction's existing behavior.

## Tests

Two multi-block cases added to `AlignmentPlugin.test.ts`, mirroring the text-direction suite:
- all blocks in a range selection get aligned
- non-alignable blocks in the range are left untouched (the `continue` branch)

## Verification

- Unit: 4405 passed (incl. the 2 new tests)
- Typecheck: clean · Lint (biome): clean · Build: succeeds
- E2E: `text-direction.spec.ts` (3 tests) passes, confirming the extraction is behavior-preserving in a real browser

## Note (out of scope)

Alignment does not `announce()` to screen readers on any path, whereas text-direction does. This is a pre-existing gap orthogonal to this bug (no a11y regression introduced); worth a separate follow-up ticket.